### PR TITLE
Improve configuration discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,8 @@ When you run `harsh` for the first time, it will set up the required files:
     Happy tracking! I genuinely hope this helps you get better.
 ```
 
-On OSX and Linux based systems, the `habits` and `log` files will be under `~/.config/harsh/`. On Windows, you can find the files under `~\AppData\`
+On OSX and Linux based systems, the `habits` and `log` files will be under `~/.config/harsh/`. On Windows, you can find the files under `%APPDATA%\harsh`.
+Alternatively, you can set a different directory using the `HARSHPATH` environment variable. 
 
 
 Open the `habits` file in your text editor of choice (nano, vim, VS Code, Sublime, or emacs). 

--- a/harsh.go
+++ b/harsh.go
@@ -451,10 +451,15 @@ func writeHabitLog(d time.Time, habit string, result string) {
 // findConfigFile checks os relevant habits and log file exist, returns path
 // If they do not exist, calls writeNewHabits and writeNewLog
 func findConfigFiles() string {
-	if runtime.GOOS == "windows" {
-		configDir = "AppData"
-	} else {
-		configDir = filepath.Join(os.Getenv("HOME"), ".config/harsh")
+
+	configDir = os.Getenv("HARSHPATH")
+
+	if (len(configDir) == 0) {
+		if runtime.GOOS == "windows" {
+			configDir = filepath.Join(os.Getenv("APPDATA"), "harsh")
+		} else {
+			configDir = filepath.Join(os.Getenv("HOME"), ".config/harsh")
+		}
 	}
 
 	if _, err := os.Stat(filepath.Join(configDir, "habits")); err == nil {


### PR DESCRIPTION
I hope it's okay that I'm skipping straight to a pull request. The code was already written while gathering information for the feature request, and I feel that the changeset is small enough.

This will:

1. Fix Windows configuration directory to use `%APPDATA%\harsh` instead of creating `.\AppData` in the current working directory; and
2. Allow users an environment variable to set a custom configuration directory.

## Background

Regarding item 1: this makes it awkward to use `harsh` from the `PATH` since data is always stored in a subdirectory of your current location. It should also use an application-specific directory (which this changeset adds).

Regarding item 2: I prefer to use the XDG Base Directory (`~/.config`) and `~/.dotfiles` conventions for easier backup and transfer across all my machines. This change would allow me to consolidate `harsh` with my other files.

## Alternatives

Two alternatives to the fix above would be to:

- always have a terminal pane open to the binary location (minor nuisance); or
- use WSL (bypassing the need for Windows, but not always available).

An alternative to a custom configuration directory would be to link the directory inside my preferred location, but this would not allow for version control and may end up saving the link instead of the contents of the link or junction.
