### PR TITLE
Small change of error message for no write access user

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -139,7 +139,7 @@ getPackage() {
                 echo "  following commands may need to be run manually."
                 echo "============================================================"
                 echo
-                echo "  sudo cp $REPO$suffix $BINLOCATION/$REPO"
+                echo "  sudo mv $installFile $BINLOCATION/$REPO"
                 echo
                 ./${REPO} --version
             else


### PR DESCRIPTION
The file has already been unpacked, so we don't need the suffix for source in the cp command. Found an already existing variable with a path to the install file, so I'm using it instead of manually composing a path. Also I'm suggesting to use mv instead of cp as the user won't need a temporary file in the directory.