### PR TITLE
Fix character length comparison in TestBuildGraph

### DIFF
--- a/harsh_test.go
+++ b/harsh_test.go
@@ -232,10 +232,13 @@ func TestBuildGraph(t *testing.T) {
 	(*entries)[DailyHabit{Day: tom, Habit: "Test"}] = Outcome{Result: "y"}
 
 	graph := h.buildGraph(habit, false)
-	length := len(graph)
-	// Due to using Builder.Grow for string efficiency, this is 10, not 8
-	if length != 10 {
-		t.Errorf("Expected graph length 10, got %d", length)
+	length := 0
+	for range graph {
+		length++
+	}
+	expectedLen := h.CountBack + 1
+	if length != expectedLen {
+		t.Errorf("Expected graph length %d, got %d", expectedLen, length)
 	}
 }
 


### PR DESCRIPTION
- Replaced len(graph) with a loop to correctly count characters, not bytes.
- Made the expected graph length dynamic instead of a hardcoded value.

The test was originally written when the graph output was `!!!!!!!━`, so len(graph) returned the correct length (10).
Now the graph output is `◌◌◌◌◌◌◌━`, which take more than ten bytes. As a result, the test fails.

This change fixes the test so it counts actual characters, not bytes, and works correctly no matter what characters the graph uses.