### PR TITLE
Fix configDir not persisting by using HARSHPATH env variable

### DIFF
--- a/harsh_test.go
+++ b/harsh_test.go
@@ -268,10 +268,11 @@ func TestNewHabitIntegration(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 
-	// Save original config dir and restore it after test
-	originalConfigDir := configDir
-	configDir = tmpDir
-	defer func() { configDir = originalConfigDir }()
+	// Set HARSHPATH to temporary directory for the duration of the test
+	os.Setenv("HARSHPATH", tmpDir)
+	defer func() {
+		os.Unsetenv("HARSHPATH")
+	}()
 
 	// Create initial habits file
 	habitsFile := filepath.Join(tmpDir, "habits")


### PR DESCRIPTION
When loading configuration using newHarsh(), it resets configDir based on the HARSHPATH environment variable. So, setting configDir directly doesn't work. This change sets HARSHPATH instead, so the correct temporary directory is used.