### PR TITLE
fix: Fix typo in pipe detection (oops)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,7 @@ func init() {
 		case "auto":
 			if color.Enable {
 				fi, _ := os.Stdout.Stat()
-				stdoutNotPiped := (fi.Mode() & os.ModeCharDevice) == 0
+				stdoutNotPiped := (fi.Mode() & os.ModeCharDevice) != 0
 				color.Enable = stdoutNotPiped;
 			}
 		default:


### PR DESCRIPTION
Pipe detection in v0.11.2 is reversed. So if harsh detects a pipe, it ENABLES the color and DISABLES when no pipe is detected.

This PR simply fixes that. Sorry for the typo lol.