### PR TITLE
feat: add heading search to ask and todo cmds

### DIFF
--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -8,6 +8,11 @@ import (
 	"github.com/wakatara/harsh/internal/ui"
 )
 
+func init() {
+	askCmd.Flags().StringVarP(&heading, "heading", "H", "", `Only ask todos from specified heading`)
+	askCmd.RegisterFlagCompletionFunc("heading", headingCompletion)
+}
+
 var askCmd = &cobra.Command{
 	Use:     "ask [habit-fragment|date|yday]",
 	Short:   "Ask and record your undone habits",
@@ -30,6 +35,7 @@ var askCmd = &cobra.Command{
 			h.GetMaxHabitNameLength(),
 			h.GetCountBack(),
 			habitFragment,
+			heading,
 		)
 		return nil
 	},
@@ -41,6 +47,16 @@ func askCmdValidArgs(cmd *cobra.Command, args []string, toComplete string) ([]co
 	for _, habit := range h.GetHabits() {
 		if strings.Contains(habit.Name, toComplete) {
 			out = append(out, habit.Name)
+		}
+	}
+	return out, cobra.ShellCompDirectiveNoFileComp
+}
+
+func headingCompletion(cmd *cobra.Command, args []string, toComplete string) ([]cobra.Completion, cobra.ShellCompDirective) {
+	out := []cobra.Completion{}
+	for _, habit := range harsh.GetHabits() {
+		if strings.Contains(habit.Heading, toComplete) {
+			out = append(out, habit.Heading)
 		}
 	}
 	return out, cobra.ShellCompDirectiveNoFileComp

--- a/cmd/ask.go
+++ b/cmd/ask.go
@@ -9,7 +9,7 @@ import (
 )
 
 func init() {
-	askCmd.Flags().StringVarP(&heading, "heading", "H", "", `Only ask todos from specified heading`)
+	askCmd.Flags().StringVar(&heading, "heading", "", `Only ask todos from specified heading`)
 	askCmd.RegisterFlagCompletionFunc("heading", headingCompletion)
 }
 

--- a/cmd/todo.go
+++ b/cmd/todo.go
@@ -13,7 +13,7 @@ var (
 
 func init() {
 	todoCmd.Flags().BoolVarP(&noPrint, "no-print", "n", false, `Don't print message when no todos are available`)
-	todoCmd.Flags().StringVarP(&heading, "heading", "H", "", `Only print todos from specified heading`)
+	todoCmd.Flags().StringVar(&heading, "heading", "", `Only print todos from specified heading`)
 	todoCmd.RegisterFlagCompletionFunc("heading", headingCompletion)
 }
 

--- a/cmd/todo.go
+++ b/cmd/todo.go
@@ -6,6 +6,17 @@ import (
 	"github.com/wakatara/harsh/internal/ui"
 )
 
+var (
+	noPrint bool
+	heading string
+)
+
+func init() {
+	todoCmd.Flags().BoolVarP(&noPrint, "no-print", "n", false, `Don't print message when no todos are available`)
+	todoCmd.Flags().StringVarP(&heading, "heading", "H", "", `Only print todos from specified heading`)
+	todoCmd.RegisterFlagCompletionFunc("heading", headingCompletion)
+}
+
 var todoCmd = &cobra.Command{
 	Use:     "todo",
 	Short:   "Show undone habits for today",
@@ -18,6 +29,8 @@ var todoCmd = &cobra.Command{
 			h.GetHabits(),
 			h.GetEntries(),
 			h.GetMaxHabitNameLength(),
+			!noPrint,
+			heading,
 		)
 		return nil
 	},

--- a/internal/ui/display.go
+++ b/internal/ui/display.go
@@ -93,7 +93,7 @@ func (d *Display) ShowHabitLog(habits []*storage.Habit, entries *storage.Entries
 	}
 
 	// Show scores and undone count
-	undone := GetTodos(habits, entries, now, 7)
+	undone := GetTodos(habits, entries, now, 7, "")
 	var undoneCount int
 	for _, v := range undone {
 		undoneCount += len(v)
@@ -173,13 +173,15 @@ func (d *Display) ShowHabitStats(habits []*storage.Habit, entries *storage.Entri
 }
 
 // ShowTodos displays undone habits for today and recent days
-func (d *Display) ShowTodos(habits []*storage.Habit, entries *storage.Entries, maxHabitNameLength int) {
+func (d *Display) ShowTodos(habits []*storage.Habit, entries *storage.Entries, maxHabitNameLength int, shouldPrintMessage bool, searchHeading string) {
 	now := civil.DateOf(time.Now())
-	undone := GetTodos(habits, entries, now, 8)
+	undone := GetTodos(habits, entries, now, 8, searchHeading)
 
 	heading := ""
 	if len(undone) == 0 {
-		fmt.Println("All todos logged up to today.")
+		if shouldPrintMessage {
+			fmt.Println("All todos logged up to today.")
+		}
 	} else {
 		// Maximum width for due dates column (e.g., "(999 days)")
 		const maxDueWidth = 10
@@ -250,7 +252,7 @@ func (d *Display) ShowTodos(habits []*storage.Habit, entries *storage.Entries, m
 }
 
 // GetTodos returns a map of date strings to habit names that are undone
-func GetTodos(habits []*storage.Habit, entries *storage.Entries, to civil.Date, daysBack int) map[string][]string {
+func GetTodos(habits []*storage.Habit, entries *storage.Entries, to civil.Date, daysBack int, searchHeading string) map[string][]string {
 	tasksUndone := map[string][]string{}
 	dayHabits := map[string]bool{}
 	from := to.AddDays(-daysBack)
@@ -273,6 +275,9 @@ func GetTodos(habits []*storage.Habit, entries *storage.Entries, to civil.Date, 
 
 			for _, habit := range habits {
 				if _, ok := (*entries)[storage.DailyHabit{Day: dt, Habit: habit.Name}]; ok {
+					delete(dayHabits, habit.Name)
+				}
+				if !strings.Contains(habit.Heading, searchHeading)  {
 					delete(dayHabits, habit.Name)
 				}
 

--- a/internal/ui/input.go
+++ b/internal/ui/input.go
@@ -54,7 +54,7 @@ func (i *Input) Onboard() int {
 }
 
 // AskHabits handles the interactive habit asking process
-func (i *Input) AskHabits(habits []*storage.Habit, entries *storage.Entries, repository storage.Repository, maxHabitNameLength int, countBack int, check string) {
+func (i *Input) AskHabits(habits []*storage.Habit, entries *storage.Entries, repository storage.Repository, maxHabitNameLength int, countBack int, check string, heading string) {
 	now := civil.DateOf(time.Now())
 	to := now
 	from := to.AddDays(-countBack - 40)
@@ -97,7 +97,7 @@ func (i *Input) AskHabits(habits []*storage.Habit, entries *storage.Entries, rep
 		filteredHabits = habits
 	}
 
-	dayHabits := GetTodos(habits, entries, to, checkBackDays)
+	dayHabits := GetTodos(habits, entries, to, checkBackDays, heading)
 
 	if len(filteredHabits) == 0 {
 		fmt.Println("You have no habits that contain that string")

--- a/test/harsh_test.go
+++ b/test/harsh_test.go
@@ -557,7 +557,7 @@ func TestNewHabitIntegration(t *testing.T) {
 
 	// Test that new habit appears in todos
 	today := civil.DateOf(time.Now())
-	todos := ui.GetTodos(harsh.GetHabits(), &harsh.GetEntries(), today, 0, "")
+	todos := ui.GetTodos(harsh.GetHabits(), harsh.GetEntries(), today, 0, "")
 
 	foundInTodos := false
 	for _, todoList := range todos {

--- a/test/harsh_test.go
+++ b/test/harsh_test.go
@@ -557,7 +557,7 @@ func TestNewHabitIntegration(t *testing.T) {
 
 	// Test that new habit appears in todos
 	today := civil.DateOf(time.Now())
-	todos := ui.GetTodos(harsh.GetHabits(), harsh.GetEntries(), today, 0)
+	todos := ui.GetTodos(harsh.GetHabits(), &harsh.GetEntries(), today, 0, "")
 
 	foundInTodos := false
 	for _, todoList := range todos {

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -107,7 +107,7 @@ func TestFullWorkflow(t *testing.T) {
 	}
 
 	// Step 9: Test todos
-	todos := ui.GetTodos(habits, &newEntries, testDate, 1, "")
+	todos := ui.GetTodos(habits, newEntries, testDate, 1, "")
 	if len(todos) == 0 {
 		t.Error("Should have todo entries")
 	}

--- a/test/integration_test.go
+++ b/test/integration_test.go
@@ -107,7 +107,7 @@ func TestFullWorkflow(t *testing.T) {
 	}
 
 	// Step 9: Test todos
-	todos := ui.GetTodos(habits, newEntries, testDate, 1)
+	todos := ui.GetTodos(habits, &newEntries, testDate, 1, "")
 	if len(todos) == 0 {
 		t.Error("Should have todo entries")
 	}
@@ -219,7 +219,7 @@ Sleep tracking: 0
 
 	// Test todos for day 4 (should include missed habits)
 	day4 := startDate.AddDays(3)
-	todos := ui.GetTodos(habits, entries, day4, 1)
+	todos := ui.GetTodos(habits, entries, day4, 1, "")
 	if len(todos) == 0 {
 		t.Error("Should have todos for day 4")
 	}

--- a/test/ui_test.go
+++ b/test/ui_test.go
@@ -71,7 +71,7 @@ func TestGetTodos(t *testing.T) {
 	}
 
 	// Test with onboarding (0 days back)
-	onboardTodos := ui.GetTodos(habits, entries, civil.Date{Year: 2025, Month: 1, Day: 15}, 0)
+	onboardTodos := ui.GetTodos(habits, entries, civil.Date{Year: 2025, Month: 1, Day: 15}, 0, "")
 	if len(onboardTodos) == 0 {
 		t.Error("Should have onboarding todos")
 	}
@@ -94,7 +94,7 @@ func TestGetTodosHabitOrderAcrossDays(t *testing.T) {
 
 	// Get todos for 3 days back
 	to := civil.Date{Year: 2025, Month: 1, Day: 15}
-	todos := ui.GetTodos(habits, entries, to, 3)
+	todos := ui.GetTodos(habits, entries, to, 3, "")
 
 	// Verify we have todos for multiple days
 	if len(todos) < 2 {
@@ -120,7 +120,7 @@ func TestGetTodosHabitOrderAcrossDays(t *testing.T) {
 
 	// Run the test multiple times to catch non-deterministic map iteration issues
 	for run := 0; run < 10; run++ {
-		todos := ui.GetTodos(habits, entries, to, 3)
+		todos := ui.GetTodos(habits, entries, to, 3, "")
 		for date, dayTodos := range todos {
 			for i, habit := range dayTodos {
 				if habit != expectedOrder[i] {
@@ -281,7 +281,7 @@ func TestDisplayShowTodos(t *testing.T) {
 	os.Stdout = w
 
 	display := ui.NewDisplay(true) // no color for testing
-	display.ShowTodos(habits, entries, 20, "")
+	display.ShowTodos(habits, entries, 20, true, "")
 
 	// Restore stdout
 	w.Close()

--- a/test/ui_test.go
+++ b/test/ui_test.go
@@ -49,7 +49,7 @@ func TestGetTodos(t *testing.T) {
 		// Test3 is missing (should be in todos)
 	}
 
-	todos := ui.GetTodos(habits, entries, civil.Date{Year: 2025, Month: 1, Day: 15}, 1)
+	todos := ui.GetTodos(habits, entries, civil.Date{Year: 2025, Month: 1, Day: 15}, 1, "")
 
 	// Should have entries for the day
 	if len(todos) == 0 {
@@ -281,7 +281,7 @@ func TestDisplayShowTodos(t *testing.T) {
 	os.Stdout = w
 
 	display := ui.NewDisplay(true) // no color for testing
-	display.ShowTodos(habits, entries, 20)
+	display.ShowTodos(habits, entries, 20, "")
 
 	// Restore stdout
 	w.Close()

--- a/test/ui_test.go
+++ b/test/ui_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"cloud.google.com/go/civil"
 	"github.com/wakatara/harsh/internal/storage"
@@ -38,9 +39,10 @@ func TestColorManager(t *testing.T) {
 
 func TestGetTodos(t *testing.T) {
 	habits := []*storage.Habit{
-		{Name: "Test1", Target: 1, Interval: 1, FirstRecord: civil.Date{Year: 2025, Month: 1, Day: 1}},
-		{Name: "Test2", Target: 1, Interval: 1, FirstRecord: civil.Date{Year: 2025, Month: 1, Day: 1}},
-		{Name: "Test3", Target: 1, Interval: 1, FirstRecord: civil.Date{Year: 2025, Month: 1, Day: 1}},
+		{Name: "Test1", Target: 1, Interval: 1, FirstRecord: civil.Date{Year: 2025, Month: 1, Day: 1}, Heading: "Work"},
+		{Name: "Test2", Target: 1, Interval: 1, FirstRecord: civil.Date{Year: 2025, Month: 1, Day: 1}, Heading: "Work"},
+		{Name: "Test3", Target: 1, Interval: 1, FirstRecord: civil.Date{Year: 2025, Month: 1, Day: 1}, Heading: "Work"},
+		{Name: "Test4", Target: 1, Interval: 1, FirstRecord: civil.Date{Year: 2025, Month: 1, Day: 1}},
 	}
 
 	entries := &storage.Entries{
@@ -49,7 +51,7 @@ func TestGetTodos(t *testing.T) {
 		// Test3 is missing (should be in todos)
 	}
 
-	todos := ui.GetTodos(habits, entries, civil.Date{Year: 2025, Month: 1, Day: 15}, 1, "")
+	todos := ui.GetTodos(habits, entries, civil.Date{Year: 2025, Month: 1, Day: 15}, 1, "Work")
 
 	// Should have entries for the day
 	if len(todos) == 0 {
@@ -60,9 +62,12 @@ func TestGetTodos(t *testing.T) {
 	found := false
 	for _, todoList := range todos {
 		for _, todo := range todoList {
+			if todo == "Test4" {
+				t.Error("Test4 shouldn't be in todos")
+				return
+			}
 			if todo == "Test3" {
 				found = true
-				break
 			}
 		}
 	}
@@ -271,9 +276,48 @@ func TestDisplayShowTodos(t *testing.T) {
 	// Create test data
 	habits := []*storage.Habit{
 		{Name: "Test1", Heading: "Work", Target: 1, Interval: 1, FirstRecord: civil.Date{Year: 2025, Month: 1, Day: 1}},
+		{Name: "Test2", Heading: "Game", Target: 1, Interval: 1, FirstRecord: civil.Date{Year: 2024, Month: 1, Day: 1}},
 	}
 
 	entries := &storage.Entries{}
+
+	// Capture stdout
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	display := ui.NewDisplay(true) // no color for testing
+	display.ShowTodos(habits, entries, 20, true, "Work")
+
+	// Restore stdout
+	w.Close()
+	os.Stdout = old
+
+	// Read captured output
+	buf := new(bytes.Buffer)
+	buf.ReadFrom(r)
+	output := buf.String()
+
+	// Should contain habit name or indicate all complete
+	if !strings.Contains(output, "Test1") && !strings.Contains(output, "All todos logged") || strings.Contains(output, "Test2"){
+		t.Errorf("Output should contain Test1 or indicate completion, and not include Test2")
+	}
+}
+
+func TestDoneHabits(t *testing.T) {
+	habits := []*storage.Habit{
+		{Name: "Test1", Heading: "Work", Target: 1, Interval: 1, FirstRecord: civil.Date{Year: 2025, Month: 1, Day: 1}},
+	}
+
+	day := civil.Date{Year: 2025, Month: 1, Day: 1}
+	entries := &storage.Entries{
+		storage.DailyHabit{Day: day, Habit: "Test1"}: {Result: "y"},
+	}
+	now := civil.DateOf(time.Now())
+	for day.Before(now) {
+		day = day.AddDays(1)
+		(*entries)[storage.DailyHabit{Day: day, Habit: "Test1"}] =  storage.Outcome{Result: "y"}
+	}
 
 	// Capture stdout
 	old := os.Stdout
@@ -293,8 +337,28 @@ func TestDisplayShowTodos(t *testing.T) {
 	output := buf.String()
 
 	// Should contain habit name or indicate all complete
-	if !strings.Contains(output, "Test1") && !strings.Contains(output, "All todos logged") {
-		t.Error("Output should contain Test1 or indicate completion")
+	if !strings.Contains(output, "All todos logged"){
+		t.Error("Output should indicate completion")
+	}
+
+	old = os.Stdout
+	r, w, _ = os.Pipe()
+	os.Stdout = w
+
+	display = ui.NewDisplay(true) // no color for testing
+	display.ShowTodos(habits, entries, 20, false, "")
+
+	// Restore stdout
+	w.Close()
+	os.Stdout = old
+
+	// Read captured output
+	buf = new(bytes.Buffer)
+	buf.ReadFrom(r)
+	output = buf.String()
+	
+	if output != "" {
+		t.Errorf("Output should be empty but is %q", output)
 	}
 }
 


### PR DESCRIPTION
using `--heading` in subcommands `ask` and `todo`, you can now show tasks that their heading includes a sub string.

this is helpful with task bracketing systems. e.g. putting harder tasks in a bracket in which you just woke up and chances of you doing the habit is higher.